### PR TITLE
and again

### DIFF
--- a/redditWallpaper.sh
+++ b/redditWallpaper.sh
@@ -22,7 +22,7 @@ IGNORE_FILES="pixel.png icon.png"
 
 # Put this parameter to 1 to only allow 1 execution per day.
 # That way, if you ever have to close & reopen your session several times, this won't execute the same thing over and over.
-ONCE_PER_DAY=1
+ONCE_PER_DAY=0
 
 ## END CONFIGURATION
 
@@ -48,11 +48,20 @@ touch "$LAST_EXEC"
 # Backup last execution's wallpapers to the backup directory
 cd "${WALLS_DIR}" && find ./  -maxdepth 1 -mindepth 1 -type f -exec mv -t ${OLD_DIR} {} +
 
+echo "# xfce backdrop list" > "${WALLS_DIR}"/index.list
+
 # Go to reddit.com/r/wallpapers, find parts of the page source that look like 'http[s?]://...png|jpg', cut the URLs out, and download them to the wallpapers directory
 wget -q -O - "$URL" 2>/dev/null | tr \< \\n | grep -E 'https?://[^"]*\.[jpng]*"' | sed -e 's!.*https\?://\([^"]*\.[jpng]*\).*!\1!g' | sort -u | while read line; do
     FILENAME=$(basename "$line")
+    DEST_FILENAME="${WALLS_DIR}/${FILENAME}"
+
+    [ -f "$DEST_FILENAME" ] && continue
+
     if ! echo "${IGNORE_FILES}" | grep -q "${FILENAME}"; then
-        wget "$line" -O "${WALLS_DIR}/${FILENAME}"
+        wget "$line" -O "$DEST_FILENAME"
     fi
+
+    echo "${WALLS_DIR}/${FILENAME}" >> "${WALLS_DIR}"/index.list
+
 done
 

--- a/redditWallpaper.sh
+++ b/redditWallpaper.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# This script goes to http://www.reddit.com/r/wallpapers, fetches a few images, and writes them to the directory of your choice.
-# Everytime you execute it, it backs up the wallpapers from the last execution to the directory of your choice.
+# This script goes to http://www.reddit.com/r/wallpapers, fetches a few images, 
+# and writes them to the directory of your choice (WALLS_DIR)
+
+# On each run, it backs up the wallpapers from the last run to the directory of your choice (OLD_DIR)
 
 # abort on error.
 set -e
@@ -21,8 +23,9 @@ OLD_DIR="$HOME/Pictures/oldwalls"
 IGNORE_FILES="pixel.png icon.png"
 
 # Put this parameter to 1 to only allow 1 execution per day.
-# That way, if you ever have to close & reopen your session several times, this won't execute the same thing over and over.
-ONCE_PER_DAY=0
+# That way, if you ever have to close & reopen your session several times, 
+# this won't execute the same thing over and over.
+ONCE_PER_DAY=1
 
 ## END CONFIGURATION
 
@@ -33,7 +36,8 @@ LAST_EXEC="${OLD_DIR}/.last_exec"
 # Make sure that said directories exist
 mkdir -p "${WALLS_DIR}" "${OLD_DIR}"
 
-# Check whether script has already been executed today, if this is the wanted behaviour. Exit without error if it is the case.
+# Check whether script has already been executed today, if this is the wanted behaviour. 
+# Exit without error if it is the case.
 if [ "$ONCE_PER_DAY" -eq 1 -a -f $LAST_EXEC ]; then
     OLD_DATE=$(date -r "$LAST_EXEC" +%D)
     TODAY=$(date +%D)
@@ -46,22 +50,45 @@ fi
 touch "$LAST_EXEC"
 
 # Backup last execution's wallpapers to the backup directory
-cd "${WALLS_DIR}" && find ./  -maxdepth 1 -mindepth 1 -type f -exec mv -t ${OLD_DIR} {} +
+
+cd "${WALLS_DIR}" && find ./  -maxdepth 1 -mindepth 1 -mtime +1 -type f -exec mv -t ${OLD_DIR} {} +
+
+ls $WALLS_DIR
 
 echo "# xfce backdrop list" > "${WALLS_DIR}"/index.list
 
-# Go to reddit.com/r/wallpapers, find parts of the page source that look like 'http[s?]://...png|jpg', cut the URLs out, and download them to the wallpapers directory
-wget -q -O - "$URL" 2>/dev/null | tr \< \\n | grep -E 'https?://[^"]*\.[jpng]*"' | sed -e 's!.*https\?://\([^"]*\.[jpng]*\).*!\1!g' | sort -u | while read line; do
-    FILENAME=$(basename "$line")
+# Go to reddit.com/r/wallpapers, 
+# find parts of the page source that look like 'http[s?]://...png|jpg', 
+# cut the URLs out, and download them to the wallpapers directory
+FILE_LIST=$( wget -q -O - "$URL" 2>/dev/null | \
+    tr \< \\n | \
+    grep -E 'https?://[^"]*\.[jpng]*"' | \
+    sed -e 's!.*\(https\?://[^"]*\.[jpng]*\).*!\1!g' | \
+    sort -u )
+
+OIFS="$IFS"
+IFS=$'\n'
+
+counter=0
+
+for IMAGE_URL in $FILE_LIST 
+do
+    FILENAME=$(basename "$IMAGE_URL")
     DEST_FILENAME="${WALLS_DIR}/${FILENAME}"
 
+    # don't duplicate/waste bandwidth
     [ -f "$DEST_FILENAME" ] && continue
 
-    if ! echo "${IGNORE_FILES}" | grep -q "${FILENAME}"; then
-        wget "$line" -O "$DEST_FILENAME"
+    if echo "${IGNORE_FILES}" | grep -q "${FILENAME}"; then
+        continue
     fi
 
-    echo "${WALLS_DIR}/${FILENAME}" >> "${WALLS_DIR}"/index.list
+    wget -q "$IMAGE_URL" -O "$DEST_FILENAME"
+    counter=$(( $counter + 1 ))
 
+    echo "${WALLS_DIR}/${FILENAME}" >> "${WALLS_DIR}"/index.list
 done
 
+IFS="$OIFS"
+
+echo "Downloaded: $counter images to $WALLS_DIR"


### PR DESCRIPTION
Hi -

Some more random changes ...

1. I use xfce, and give it a list of images to use - so we now build this as index.list.
2 .Only move images to the old dir if they're more than 1 day old... (assumes I've remembered units for find's -mtime correctly...)
3. Break up some of the longer lines
4. Do not download a file if it already exists
5. Keep the http/https prefix to the URLs - I suppose it's possible that a site may respond to only https and not http
6. Display a "6 files were downloaded" sort of text at the end.